### PR TITLE
Check for a ParseError when loading the history

### DIFF
--- a/pastielib/protector.py
+++ b/pastielib/protector.py
@@ -24,6 +24,7 @@ import keybinder
 import os
 import os.path
 import xml.etree.ElementTree as tree
+from xml.etree.ElementTree import ParseError as ParseError
 from xml.parsers.expat import ExpatError
 import base64
 import hashlib
@@ -139,6 +140,8 @@ class ClipboardProtector(object):
 		except IOError: # file doesn't exist
 			return tmp_list
 		except ExpatError: # file is empty or malformed
+			return tmp_list
+		except ParseError: # file is empty (not element found)
 			return tmp_list
 		
 		for item in history_tree.findall("item"):


### PR DESCRIPTION
When for whatever reason we get an empty clipboard_history file a ParseError is throw.

What I have done is simply catch this exception and return the empty list as we can't know what we have in the history file.

This is very similar to issue #4 . I don't know why but the raised exception is now ParseError.

I'm using Ubuntu 14.04